### PR TITLE
Included notifications table for notifications tab

### DIFF
--- a/auction.sql
+++ b/auction.sql
@@ -390,8 +390,26 @@ VALUES
     ('user5', '9876534523456666', '456 Refent St, London');
 
 
-
 -- --------------------------------------------------------
+
+-- Table structure for table `notifications`
+
+CREATE TABLE IF NOT EXISTS notifications (
+  notification_id INT AUTO_INCREMENT PRIMARY KEY,
+  username VARCHAR(30) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
+  auction_id INT(10) UNSIGNED,
+  message TEXT NOT NULL,
+  type ENUM('bidding', 'auction', 'watchlist') NOT NULL,  -- Updated ENUM values for categorisation
+  is_read BOOLEAN DEFAULT FALSE,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (username) REFERENCES users(username)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE,
+  FOREIGN KEY (auction_id) REFERENCES auction(auction_id)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
 
 -- Final configuration and cleanup
 


### PR DESCRIPTION
Changes:
Added a notifications table to the database schema.
Table Structure and columns:
notification_id: Primary key.
username: Recipient of the notification.
auction_id: Auction related to the notification.
message: Text of the notification.
type: Type of notification (e.g., 'bidding', 'auction', 'watchlist').
is_read: Boolean to indicate if the notification has been read.
created_at: Timestamp for when the notification was created.