### PR TITLE
Created fetch_unread_count.php

### DIFF
--- a/base code/fetch_unread_count.php
+++ b/base code/fetch_unread_count.php
@@ -1,0 +1,32 @@
+<?php
+include_once("connection.php");
+
+// Start the session
+if (session_status() == PHP_SESSION_NONE) {
+    session_start();
+}
+
+$response = ['unread_count' => 0]; // Default response
+
+// Check if the user is logged in
+if (isset($_SESSION['username'])) {
+    $username = $_SESSION['username'];
+
+    // Query to get the unread count
+    $unread_count_sql = "SELECT COUNT(*) AS unread_count FROM notifications WHERE username = ? AND is_read = FALSE";
+    $stmt = $conn->prepare($unread_count_sql);
+    if ($stmt) {
+        $stmt->bind_param("s", $username);
+        $stmt->execute();
+        $stmt->bind_result($unread_count);
+        $stmt->fetch();
+        $stmt->close();
+
+        $response['unread_count'] = $unread_count;
+    }
+}
+
+// Return the unread count as a JSON response
+header('Content-Type: application/json');
+echo json_encode($response);
+?>


### PR DESCRIPTION
Purpose: It is used to fetch the count of unread notifications for the logged-in user. Usage:
This file is called by the AJAX script in notifications.php to get the real-time unread notification count, allowing for dynamic updates on the page. Without this, the unread badge count won't be updated in real-time.